### PR TITLE
Split API key into two parts

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,20 @@ This package implements the [libdns interfaces](https://github.com/libdns/libdns
 
 ## Authenticating
 
-This package supports API **token** authentication.
+> [!IMPORTANT]
+> This package supports API **token** authentication (as opposed to legacy API **keys**).
 
-You will need to create a token with the following permissions:
+There are two approaches for token permissions supported by this package: 
+1. Single token for everything
+    - `APIToken` permissions required: Zone:Read, Zone.DNS:Write - All zones
+2. Dual token method
+    - `ZoneToken` permissions required: Zone:Read - All zones
+    - `APIToken` permissions required: Zone.DNS:Write - for the zone(s) you wish to manage
 
-- Zone / Zone / Read
-- Zone / DNS / Edit
+The dual token method allows users who have multiple DNS zones in their Cloudflare account to restrict which zones the token can access, whereas the first method will allow access to all DNS Zones.
+If you only have one domain/zone then this approach does not provide any benefit, and you might as well just have the single API token
 
-The first permission is needed to get the zone ID, and the second permission is obviously necessary to edit the DNS records. If you're only using the `GetRecords()` method, you can change the second permission to Read to guarantee no changes will be made.
+To use the dual token approach simply ensure that the `ZoneToken` property is provided - otherwise the package will use `APIToken` for all API requests.
 
 To clarify, do NOT use API keys, which are globally-scoped:
 

--- a/client.go
+++ b/client.go
@@ -98,6 +98,9 @@ func (p *Provider) getZoneInfo(ctx context.Context, zoneName string) (cfZone, er
 		return cfZone{}, err
 	}
 
+	if p.ZoneToken != "" {
+		req.Header.Set("Authorization", "Bearer "+p.ZoneToken)
+	}
 	var zones []cfZone
 	_, err = p.doAPIRequest(req, &zones)
 	if err != nil {
@@ -113,13 +116,15 @@ func (p *Provider) getZoneInfo(ctx context.Context, zoneName string) (cfZone, er
 	return zones[0], nil
 }
 
-// doAPIRequest authenticates the request req and does the round trip. It returns
-// the decoded response from Cloudflare if successful; otherwise it returns an
+// doAPIRequest does the round trip, adding Authorization header if not already supplied.
+// It returns the decoded response from Cloudflare if successful; otherwise it returns an
 // error including error information from the API if applicable. If result is a
 // non-nil pointer, the result field from the API response will be decoded into
 // it for convenience.
 func (p *Provider) doAPIRequest(req *http.Request, result interface{}) (cfResponse, error) {
-	req.Header.Set("Authorization", "Bearer "+p.APIToken)
+	if req.Header.Get("Authorization") == "" {
+		req.Header.Set("Authorization", "Bearer "+p.APIToken)
+	}
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/provider.go
+++ b/provider.go
@@ -12,12 +12,10 @@ import (
 // Provider implements the libdns interfaces for Cloudflare.
 // TODO: Support pagination and retries, handle rate limits.
 type Provider struct {
-	// API token is used for authentication. Make sure to use a
-	// scoped API **token**, NOT a global API **key**. It will
-	// need two permissions: Zone-Zone-Read and Zone-DNS-Edit,
-	// unless you are only using `GetRecords()`, in which case
-	// the second can be changed to Read.
-	APIToken string `json:"api_token,omitempty"`
+	// API tokens are used for authentication. Make sure to use
+	// scoped API **tokens**, NOT a global API **key**.
+	APIToken  string `json:"api_token,omitempty"`  // API token with Zone.DNS:Write (can be scoped to single Zone if ZoneToken is also provided)
+	ZoneToken string `json:"zone_token,omitempty"` // Optional Zone:Read token (global scope)
 
 	zones   map[string]cfZone
 	zonesMu sync.Mutex


### PR DESCRIPTION
## Overview

This PR allows for a second API token to be optionally configured, used for the API call in the `getZoneInfo()` function.

The change is backwards compatible with existing configs - if the Zone API token is not provided, the regular API token is used for all requests.

## Why

The `/zones` API endpoint requires that the entire token be scoped globally, which then means that the DNS edit permission must also be scoped globally. This prevents the use of a single API token to perform DNS updates to be restricted to a single zone in a multi-zone account.

By splitting the token used by `getZoneInfo()` out, this global scoped token can be left as read-only, and the DNS read/write token can be scoped to a single Zone.

Solves #4 

## Testing

I've personally tested this working over [here](https://github.com/aliask/caddy-cloudflare/tree/optional-scoped-api-keys), and if this PR is merged I'll hope to contribute the update to the Caddy provider.