### PR TITLE
fix TXT record not wrapped in quotes

### DIFF
--- a/models.go
+++ b/models.go
@@ -149,6 +149,10 @@ func cloudflareRecord(r libdns.Record) (cfDNSRecord, error) {
 		rec.Data.Name = srv.Name
 		rec.Data.Port = srv.Port
 		rec.Data.Target = srv.Target
+	} else if r.Type == "TXT" {
+		// make sure the content is wrapped in quotes
+		rec.Name = r.Name
+		rec.Content = `"` + strings.Trim(r.Value, `"`) + `"`
 	} else {
 		rec.Name = r.Name
 		rec.Content = r.Value


### PR DESCRIPTION
According to the doc of Cloudflare, quotation marks is required for TXT record.
https://www.cloudflare.com/learning/dns/dns-records/dns-txt-record/

fix https://github.com/caddy-dns/cloudflare/issues/89
