### PR TITLE
Enable proxy for Cloudflare tunnel CNAME records

### DIFF
--- a/models.go
+++ b/models.go
@@ -167,6 +167,9 @@ func cloudflareRecord(r libdns.Record) (cfDNSRecord, error) {
 		rec.Data.Priority = r.Priority
 		rec.Content = r.Value
 	}
+	if rec.Type == "CNAME" && strings.HasSuffix(rec.Content, ".cfargotunnel.com") {
+		rec.Proxied = true
+	}
 	return rec, nil
 }
 


### PR DESCRIPTION
This commit checks if the record is a CNAME that ends with `.cfargotunnel.com`
and if so, it will enable Cloudflare proxying for that record.

Note that a `cfargotunnel.com` record that does not have proxying
enabled cannot work ever, so there's no reason to ever not do this.
