### PR TITLE
Upgrade to libdns v1 beta APIs

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,11 +59,13 @@ func (p *Provider) updateRecord(ctx context.Context, oldRec, newRec cfDNSRecord)
 }
 
 func (p *Provider) getDNSRecords(ctx context.Context, zoneInfo cfZone, rec libdns.Record, matchContent bool) ([]cfDNSRecord, error) {
+	rr := rec.RR()
+
 	qs := make(url.Values)
-	qs.Set("type", rec.Type)
-	qs.Set("name", libdns.AbsoluteName(rec.Name, zoneInfo.Name))
+	qs.Set("type", rr.Type)
+	qs.Set("name", libdns.AbsoluteName(rr.Name, zoneInfo.Name))
 	if matchContent {
-		qs.Set("content", rec.Value)
+		qs.Set("content", rr.Data)
 	}
 
 	reqURL := fmt.Sprintf("%s/zones/%s/dns_records?%s", baseURL, zoneInfo.ID, qs.Encode())
@@ -121,7 +123,7 @@ func (p *Provider) getZoneInfo(ctx context.Context, zoneName string) (cfZone, er
 // error including error information from the API if applicable. If result is a
 // non-nil pointer, the result field from the API response will be decoded into
 // it for convenience.
-func (p *Provider) doAPIRequest(req *http.Request, result interface{}) (cfResponse, error) {
+func (p *Provider) doAPIRequest(req *http.Request, result any) (cfResponse, error) {
 	if req.Header.Get("Authorization") == "" {
 		req.Header.Set("Authorization", "Bearer "+p.APIToken)
 	}

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/libdns/cloudflare
 
 go 1.18
 
-require github.com/libdns/libdns v0.2.3
+require github.com/libdns/libdns v1.0.0-beta.1

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,2 @@
-github.com/libdns/libdns v0.2.3 h1:ba30K4ObwMGB/QTmqUxf3H4/GmUrCAIkMWejeGl12v8=
-github.com/libdns/libdns v0.2.3/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=
+github.com/libdns/libdns v1.0.0-beta.1 h1:KIf4wLfsrEpXpZ3vmc/poM8zCATXT2klbdPe6hyOBjQ=
+github.com/libdns/libdns v1.0.0-beta.1/go.mod h1:4Bj9+5CQiNMVGf87wjX4CY3HQJypUHRuLvlsfsZqLWQ=

--- a/models.go
+++ b/models.go
@@ -81,9 +81,9 @@ type cfDNSRecord struct {
 		Service  string `json:"service,omitempty"`
 		Proto    string `json:"proto,omitempty"`
 		Name     string `json:"name,omitempty"`
-		Priority uint   `json:"priority,omitempty"`
-		Weight   uint   `json:"weight,omitempty"`
-		Port     uint   `json:"port,omitempty"`
+		Priority uint16 `json:"priority,omitempty"`
+		Weight   uint16 `json:"weight,omitempty"`
+		Port     uint16 `json:"port,omitempty"`
 		Target   string `json:"target,omitempty"`
 		Value    string `json:"value,omitempty"`
 
@@ -110,67 +110,56 @@ type cfDNSRecord struct {
 	} `json:"meta,omitempty"`
 }
 
-func (r cfDNSRecord) libdnsRecord(zone string) libdns.Record {
-	if r.Type == "SRV" {
-		srv := libdns.SRV{
-			Service:  strings.TrimPrefix(r.Data.Service, "_"),
-			Proto:    strings.TrimPrefix(r.Data.Proto, "_"),
-			Name:     r.Data.Name,
-			Priority: r.Data.Priority,
-			Weight:   r.Data.Weight,
-			Port:     r.Data.Port,
-			Target:   r.Data.Target,
-		}
-		return srv.ToRecord()
-	}
-	rec := libdns.Record{
-		Type:  r.Type,
-		Name:  libdns.RelativeName(r.Name, zone),
-		Value: r.Content,
-		TTL:   time.Duration(r.TTL) * time.Second,
-		ID:    r.ID,
-	}
-	if r.Type == "HTTPS" {
-		rec.Value = r.Data.Value
-		rec.Priority = r.Data.Priority
-		rec.Target = r.Data.Target
-	}
-	return rec
+func (r cfDNSRecord) libdnsRecord(zone string) (libdns.Record, error) {
+	return libdns.RR{
+		Name: libdns.RelativeName(r.Name, zone),
+		TTL:  time.Duration(r.TTL) * time.Second,
+		Type: r.Type,
+		Data: r.Content,
+	}.Parse()
 }
 
 func cloudflareRecord(r libdns.Record) (cfDNSRecord, error) {
-	rec := cfDNSRecord{
-		ID:   r.ID,
-		Type: r.Type,
-		TTL:  int(r.TTL.Seconds()),
+	// Super annoyingly, the Cloudflare API says that a "Content"
+	// field can contain the record data as a string, and that the
+	// individual component fields are optional (this would be
+	// ideal so we don't have to parse every single record type
+	// into a separate struct, we can just submit the Content
+	// string like what the RR struct has for us); yet when I try
+	// to submit records using the Content field, I get errors
+	// saying that the individual data components are required,
+	// despite the docs saying they're optional.
+	// So, instead of a 5-line function, we have a much bigger
+	// more complicated and error prone function here.
+	// And of course there's no real good venue to file a bug report:
+	// https://community.cloudflare.com/t/creating-srv-record-with-content-string-instead-of-individual-component-fields/781178?u=mholt
+	rr := r.RR()
+	cfRec := cfDNSRecord{
+		// ID:   r.ID,
+		Name:    rr.Name,
+		Type:    rr.Type,
+		TTL:     int(rr.TTL.Seconds()),
+		Content: rr.Data,
 	}
-	switch r.Type {
-	case "SRV":
-		srv, err := r.ToSRV()
-		if err != nil {
-			return cfDNSRecord{}, err
-		}
-		rec.Data.Service = "_" + srv.Service
-		rec.Data.Priority = srv.Priority
-		rec.Data.Weight = srv.Weight
-		rec.Data.Proto = "_" + srv.Proto
-		rec.Data.Name = srv.Name
-		rec.Data.Port = srv.Port
-		rec.Data.Target = srv.Target
-	case "HTTPS":
-		rec.Name = r.Name
-		rec.Data.Priority = r.Priority
-		rec.Data.Target = r.Target
-		rec.Data.Value = r.Value
-	default:
-		rec.Name = r.Name
-		rec.Data.Priority = r.Priority
-		rec.Content = r.Value
+	switch rec := r.(type) {
+	case libdns.SRV:
+		cfRec.Data.Service = "_" + rec.Service
+		cfRec.Data.Priority = rec.Priority
+		cfRec.Data.Weight = rec.Weight
+		cfRec.Data.Proto = "_" + rec.Transport
+		cfRec.Data.Name = rec.Name
+		cfRec.Data.Port = rec.Port
+		cfRec.Data.Target = rec.Target
+	case libdns.ServiceBinding:
+		cfRec.Name = rec.Name
+		cfRec.Data.Priority = rec.Priority
+		cfRec.Data.Target = rec.Target
+		cfRec.Data.Value = rec.Params.String()
 	}
-	if rec.Type == "CNAME" && strings.HasSuffix(rec.Content, ".cfargotunnel.com") {
-		rec.Proxied = true
+	if rr.Type == "CNAME" && strings.HasSuffix(cfRec.Content, ".cfargotunnel.com") {
+		cfRec.Proxied = true
 	}
-	return rec, nil
+	return cfRec, nil
 }
 
 // All API responses have this structure.


### PR DESCRIPTION
This change _basically_ brings this package into conformance with the new libdns 1.0 APIs (currently in beta; but unlikely to change much now).

The loss of record IDs is one thing I'm not 100% sure about, but this code worked well in getting certificates (which calls GetRecords and DeleteRecords), and setting ECH parameters (which calls GetRecords and SetRecords).