### PR TITLE
Fix specific record types not being parsed correctly

### DIFF
--- a/provider.go
+++ b/provider.go
@@ -3,7 +3,6 @@ package cloudflare
 import (
 	"context"
 	"fmt"
-	"log"
 	"net/http"
 	"sync"
 
@@ -49,7 +48,6 @@ func (p *Provider) GetRecords(ctx context.Context, zone string) ([]libdns.Record
 		}
 		recs = append(recs, libdnsRec)
 	}
-	log.Printf("GOT RECORDS: %#v", recs)
 
 	return recs, nil
 }


### PR DESCRIPTION
This change specifically applies to MX and SRV records as all other record types got parsed correctly already.

Some of Cloudflare's API responses for specific record types do not include the raw DNS record content in the `Content` field. For example, `MX` records would have a content of `example.com` instead of `<PRIORITY> example.com`, making them unable to be properly parsed.

To solve this, we use the structured record data already provided to us by Cloudflare's API wherever it makes sense, and fallback to the libdns parsing when it makes sense.