### PR TITLE
Add options for constructing provider, including custom http client

### DIFF
--- a/client.go
+++ b/client.go
@@ -128,7 +128,7 @@ func (p *Provider) doAPIRequest(req *http.Request, result any) (cfResponse, erro
 		req.Header.Set("Authorization", "Bearer "+p.APIToken)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.httpClient.Do(req)
 	if err != nil {
 		return cfResponse{}, err
 	}

--- a/provider.go
+++ b/provider.go
@@ -47,7 +47,7 @@ func NewProvider(apiToken string, opts ...ProviderOpt) *Provider {
 	return provider
 }
 
-// Options to construct provider
+// ProviderOpt are options to construct provider
 type ProviderOpt func(p *Provider)
 
 // WithZoneToken allows using additional zone token for authorization


### PR DESCRIPTION
Adds new function for constructing `Provider` instance

```golang
func NewProvider(apiToken string, opts ...ProviderOpt) *Provider
```

This function takes an api token, as that is always required for the provider to function. 

Additionally I added two construction options

```golang
func WithZoneToken(token string) ProviderOpt
func WithHttpClient(h Httper) ProviderOpt
```

`WithZoneToken` allows constructing the provider with the optional zone token, for dual authentication as specified in docs.

`WithHttpClient` allows passing an underlying http client interface (`Do(req *http.Request) (*http.Response, error)`). I added this option as it can be useful to provide your own http client. I am currently experiencing issues with deleting `TXT` records with this library (similar to [this issue](https://github.com/libdns/cloudflare/pull/13#issuecomment-2586157287)), and I want to provide my own http client to debug the requests/responses.  

@mholt please let me know what you think and if this is a valid request to merge. 