### PR TITLE
Ability to set custom http client 

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,3 +29,21 @@ To clarify, do NOT use API keys, which are globally-scoped:
 DO use scoped API tokens:
 
 ![Don't use API keys](https://user-images.githubusercontent.com/1128849/81196503-5c91d800-8f7c-11ea-93cc-ad7d73420fab.png)
+
+## Example Configuration
+
+```golang
+// With Auth
+p := cloudflare.Provider{
+    APIToken: "apitoken",
+    ZoneToken: "zonetoken", // optional
+}
+
+// With Custom HTTP Client
+p := cloudflare.Provider{
+    APIToken: "apitoken",
+ HTTPClient: http.Client{
+  Timeout: 10 * time.Second,
+    },
+}
+```

--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ p := cloudflare.Provider{
 // With Custom HTTP Client
 p := cloudflare.Provider{
     APIToken: "apitoken",
- HTTPClient: http.Client{
-  Timeout: 10 * time.Second,
+    HTTPClient: http.Client{
+        Timeout: 10 * time.Second,
     },
 }
 ```

--- a/client.go
+++ b/client.go
@@ -118,6 +118,14 @@ func (p *Provider) getZoneInfo(ctx context.Context, zoneName string) (cfZone, er
 	return zones[0], nil
 }
 
+// getClient returns http client to use
+func (p *Provider) getClient() HTTPClient {
+	if p.HTTPClient == nil {
+		return http.DefaultClient
+	}
+	return p.HTTPClient
+}
+
 // doAPIRequest does the round trip, adding Authorization header if not already supplied.
 // It returns the decoded response from Cloudflare if successful; otherwise it returns an
 // error including error information from the API if applicable. If result is a
@@ -128,7 +136,7 @@ func (p *Provider) doAPIRequest(req *http.Request, result any) (cfResponse, erro
 		req.Header.Set("Authorization", "Bearer "+p.APIToken)
 	}
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := p.getClient().Do(req)
 	if err != nil {
 		return cfResponse{}, err
 	}

--- a/provider.go
+++ b/provider.go
@@ -21,7 +21,7 @@ type Provider struct {
 	APIToken  string `json:"api_token,omitempty"`  // API token with Zone.DNS:Write (can be scoped to single Zone if ZoneToken is also provided)
 	ZoneToken string `json:"zone_token,omitempty"` // Optional Zone:Read token (global scope)
 
-    // HTTPClient is the client used to communicate with Cloudflare.
+	// HTTPClient is the client used to communicate with Cloudflare.
 	// If nil, a default client will be used.
 	HTTPClient HTTPClient
 

--- a/provider.go
+++ b/provider.go
@@ -9,6 +9,10 @@ import (
 	"github.com/libdns/libdns"
 )
 
+type HTTPClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
 // Provider implements the libdns interfaces for Cloudflare.
 // TODO: Support pagination and retries, handle rate limits.
 type Provider struct {
@@ -16,6 +20,10 @@ type Provider struct {
 	// scoped API **tokens**, NOT a global API **key**.
 	APIToken  string `json:"api_token,omitempty"`  // API token with Zone.DNS:Write (can be scoped to single Zone if ZoneToken is also provided)
 	ZoneToken string `json:"zone_token,omitempty"` // Optional Zone:Read token (global scope)
+
+    // HTTPClient is the client used to communicate with Cloudflare.
+	// If nil, a default client will be used.
+	HTTPClient HTTPClient
 
 	zones   map[string]cfZone
 	zonesMu sync.Mutex

--- a/provider.go
+++ b/provider.go
@@ -23,7 +23,7 @@ type Provider struct {
 
 	// HTTPClient is the client used to communicate with Cloudflare.
 	// If nil, a default client will be used.
-	HTTPClient HTTPClient
+    HTTPClient HTTPClient `json:"-"`
 
 	zones   map[string]cfZone
 	zonesMu sync.Mutex

--- a/provider.go
+++ b/provider.go
@@ -23,7 +23,7 @@ type Provider struct {
 
 	// HTTPClient is the client used to communicate with Cloudflare.
 	// If nil, a default client will be used.
-    HTTPClient HTTPClient `json:"-"`
+	HTTPClient HTTPClient `json:"-"`
 
 	zones   map[string]cfZone
 	zonesMu sync.Mutex


### PR DESCRIPTION
Adds a public struct field so users can set custom http client.

@mholt I looked through other libdns implementations and this seems to be a common way to set http client for provider. Let me know if this is acceptable. 