### PR TITLE
Using content.exact to fix matching for content values with special characters

### DIFF
--- a/client.go
+++ b/client.go
@@ -65,7 +65,7 @@ func (p *Provider) getDNSRecords(ctx context.Context, zoneInfo cfZone, rec libdn
 	qs.Set("type", rr.Type)
 	qs.Set("name", libdns.AbsoluteName(rr.Name, zoneInfo.Name))
 	if matchContent {
-		qs.Set("content", rr.Data)
+		qs.Set("content.exact", rr.Data)
 	}
 
 	reqURL := fmt.Sprintf("%s/zones/%s/dns_records?%s", baseURL, zoneInfo.ID, qs.Encode())


### PR DESCRIPTION
Hi!

  I've found that when using special characters in the `content` value for a `TXT` record the matching in existing `getDNSRecords()` doesn't work. This private function is used to help the `DELETE` operation, so this issue would only be found on delete.

The [Cloudflare documentation](https://developers.cloudflare.com/api/resources/dns/subresources/records/methods/list/) seems to suggest that `content.exact` is the filtering query parameter to use, but the code is using `content` instead.

![image](https://github.com/user-attachments/assets/6646ad5e-cdda-45bd-a6b8-eac907a03b8c)

 I've prepared a [script](https://gist.github.com/rayjanoka/49035e2360a2de5ed78285e7922ecd29) that demonstrates the issue with CloudFlare's API when using `content` vs `content.exact` for the record. 

In the screenshot of the script where several content values are tested, with the last 2 including special characters, like a comma. The `TXT` record with the special character in the `content` field is created successfully, but then when it is listed with the `content` filter key it isn't found, however when using `content.exact` as the filter key with the same value it always works.

![image](https://github.com/user-attachments/assets/61f44e6c-997e-41c2-b1eb-2dfbe53abd90)
