### PR TITLE
Adding double-quotes to TXT record content

### DIFF
--- a/client.go
+++ b/client.go
@@ -59,13 +59,16 @@ func (p *Provider) updateRecord(ctx context.Context, oldRec, newRec cfDNSRecord)
 }
 
 func (p *Provider) getDNSRecords(ctx context.Context, zoneInfo cfZone, rec libdns.Record, matchContent bool) ([]cfDNSRecord, error) {
-	rr := rec.RR()
+	rr, err := cloudflareRecord(rec)
+	if err != nil {
+		return nil, err
+	}
 
 	qs := make(url.Values)
 	qs.Set("type", rr.Type)
 	qs.Set("name", libdns.AbsoluteName(rr.Name, zoneInfo.Name))
 	if matchContent {
-		qs.Set("content", rr.Data)
+		qs.Set("content", rr.Content)
 	}
 
 	reqURL := fmt.Sprintf("%s/zones/%s/dns_records?%s", baseURL, zoneInfo.ID, qs.Encode())

--- a/models.go
+++ b/models.go
@@ -231,8 +231,8 @@ func cloudflareRecord(r libdns.Record) (cfDNSRecord, error) {
 	}
 	switch rec := r.(type) {
 	case libdns.TXT:
+		// If the content is not wrapped in quotes, wrap the content in double quotes
 		if !(strings.HasPrefix(cfRec.Content, `"`) && strings.HasSuffix(cfRec.Content, `"`)) {
-			// If the content is not wrapped in quotes, wrap the content in double quotes
 			cfRec.Content = fmt.Sprintf("%q", cfRec.Content)
 		}
 	case libdns.SRV:

--- a/models.go
+++ b/models.go
@@ -184,7 +184,7 @@ func (r cfDNSRecord) libdnsRecord(zone string) (libdns.Record, error) {
 		return libdns.TXT{
 			Name: name,
 			TTL:  ttl,
-			Text: r.Content,
+			Text: strings.TrimPrefix(strings.TrimSuffix(r.Content, `"`), `"`),
 		}, nil
 	// NOTE: HTTPS records from Cloudflare have a `r.Content` that can be
 	// parsed by [libdns.RR.Parse] so that is what we do here. While we are
@@ -225,6 +225,10 @@ func cloudflareRecord(r libdns.Record) (cfDNSRecord, error) {
 		Content: rr.Data,
 	}
 	switch rec := r.(type) {
+	case libdns.TXT:
+		if !(strings.HasPrefix(cfRec.Content, `"`) && strings.HasSuffix(cfRec.Content, `"`)) {
+			cfRec.Content = fmt.Sprintf(`"%s"`, cfRec.Content)
+		}
 	case libdns.SRV:
 		cfRec.Data.Service = "_" + rec.Service
 		cfRec.Data.Priority = rec.Priority

--- a/models.go
+++ b/models.go
@@ -232,7 +232,7 @@ func cloudflareRecord(r libdns.Record) (cfDNSRecord, error) {
 	switch rec := r.(type) {
 	case libdns.TXT:
 		// If the content is not wrapped in quotes, wrap the content in double quotes
-		if !(strings.HasPrefix(cfRec.Content, `"`) && strings.HasSuffix(cfRec.Content, `"`)) {
+		if !strings.HasPrefix(cfRec.Content, `"`) && !strings.HasSuffix(cfRec.Content, `"`) {
 			cfRec.Content = fmt.Sprintf("%q", cfRec.Content)
 		}
 	case libdns.SRV:


### PR DESCRIPTION
Hey, 

Got another one. This one is a bit cosmetic, but the provider is not adding the double-quotes to the content of the TXT record.

The lack of double-quotes results in this warning in the Cloudflare UI.

![image](https://github.com/user-attachments/assets/3f159048-95ae-4fcb-b770-9de7650195c3)

The [Cloudflare documentation](https://developers.cloudflare.com/dns/manage-dns-records/reference/dns-record-types/#txt) suggests that they may add the double-quotes themselves if they need to, and I found that their UI does automatically add the double-quotes on create if they are not provided.

According to the `libdns` docs [here](https://github.com/libdns/libdns/blob/6be57668e7bf10f6c31ab7ffcd7cc132766c1ee2/rrtypes.go#L410-L415) the provider should be handling this.

This change:
1. Adds the double-quotes to the `content` field on the way to Cloudflare if they don't exist
2. Removes the double-quotes to the `content` field on the way to libdns if they do exist
3. Adds usage of `cloudflareRecord()` in `getDNSRecords()` to give the opportunity to add the double-quotes to the read operation to get a successful `content` match when deleting records.

TODO:
1. I need to see if this is backward compatible...